### PR TITLE
make duration tracking consistent with `Albelli.Correlation.Http.Server`

### DIFF
--- a/src/Albelli.Correlation.Http.Client/Handlers/LoggingDelegatingHandler.cs
+++ b/src/Albelli.Correlation.Http.Client/Handlers/LoggingDelegatingHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Albelli.Correlation.Http.Client.Configuration;
 using Albelli.Correlation.Http.Client.Logging;
+using Albumprinter.CorrelationTracking.Correlation.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,7 +11,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Albumprinter.CorrelationTracking.Correlation.Core;
 
 namespace Albelli.Correlation.Http.Client.Handlers
 {
@@ -79,7 +79,7 @@ namespace Albelli.Correlation.Http.Client.Handlers
                     }
 
                     using (LogProvider.OpenMappedContext(CorrelationKeys.OperationId, operationId))
-                    using (LogProvider.OpenMappedContext(ContextKeys.Duration, stopWatch.Elapsed))
+                    using (LogProvider.OpenMappedContext(ContextKeys.Duration, (int)Math.Ceiling(stopWatch.Elapsed.TotalMilliseconds)))
                     using (LogProvider.OpenMappedContext(ContextKeys.StatusCode, response.StatusCode))
                     {
                         _log.Log(ToLevel(response.StatusCode), () => output.ToString());


### PR DESCRIPTION
Log duration as the number of milliseconds instead of TimeSpan.
For example, the duration for 1-second-call will be logged as `1000`, but not `00:00:01:000000`