### PR TITLE
track http status code as integer

### DIFF
--- a/src/Albelli.Correlation.Http.Client/Handlers/LoggingDelegatingHandler.cs
+++ b/src/Albelli.Correlation.Http.Client/Handlers/LoggingDelegatingHandler.cs
@@ -80,7 +80,7 @@ namespace Albelli.Correlation.Http.Client.Handlers
 
                     using (LogProvider.OpenMappedContext(CorrelationKeys.OperationId, operationId))
                     using (LogProvider.OpenMappedContext(ContextKeys.Duration, (int)Math.Ceiling(stopWatch.Elapsed.TotalMilliseconds)))
-                    using (LogProvider.OpenMappedContext(ContextKeys.StatusCode, response.StatusCode))
+                    using (LogProvider.OpenMappedContext(ContextKeys.StatusCode, (int)response.StatusCode))
                     {
                         _log.Log(ToLevel(response.StatusCode), () => output.ToString());
                     }


### PR DESCRIPTION
make HTTP status code tracking consistent with `Albelli.Correlation.Http.Server`
e.g. HTTP 200 OK will be logged as `200` instead of `OK`