### PR TITLE
Null request context impedes scenario runners from starting execution

### DIFF
--- a/src/Albelli.Correlation.AmazonSns/SnsCorrelationHeaderPipelineHandler.cs
+++ b/src/Albelli.Correlation.AmazonSns/SnsCorrelationHeaderPipelineHandler.cs
@@ -26,7 +26,10 @@ namespace Albelli.Correlation.AmazonSns
             var awsRequest = requestContext?.Request;
             if (awsRequest != null && !awsRequest.Headers.ContainsKey(CorrelationKeys.CorrelationId))
             {
-                awsRequest.Headers[CorrelationKeys.CorrelationId] = CorrelationScope.Current.CorrelationId.ToString();
+                if (CorrelationScope.Current != null)
+                {
+                    awsRequest.Headers[CorrelationKeys.CorrelationId] = CorrelationScope.Current.CorrelationId.ToString();
+                }
             }
         }
     }

--- a/src/Albelli.Correlation.AmazonSns/SnsCorrelationHeaderPipelineHandler.cs
+++ b/src/Albelli.Correlation.AmazonSns/SnsCorrelationHeaderPipelineHandler.cs
@@ -26,9 +26,10 @@ namespace Albelli.Correlation.AmazonSns
             var awsRequest = requestContext?.Request;
             if (awsRequest != null && !awsRequest.Headers.ContainsKey(CorrelationKeys.CorrelationId))
             {
-                if (CorrelationScope.Current != null)
+                var currentScope = CorrelationScope.Current;
+                if (currentScope != null)
                 {
-                    awsRequest.Headers[CorrelationKeys.CorrelationId] = CorrelationScope.Current.CorrelationId.ToString();
+                    awsRequest.Headers[CorrelationKeys.CorrelationId] = currentScope.CorrelationId.ToString();
                 }
             }
         }

--- a/src/Albelli.Correlation.AmazonSns/SnsCorrelationHeaderPipelineHandler.cs
+++ b/src/Albelli.Correlation.AmazonSns/SnsCorrelationHeaderPipelineHandler.cs
@@ -23,7 +23,7 @@ namespace Albelli.Correlation.AmazonSns
         private static void AddCorrelationAttributeIfAbsent(IRequestContext requestContext)
         {
             //that piece of code works only *after* Marshaller
-            var awsRequest = requestContext.Request;
+            var awsRequest = requestContext?.Request;
             if (awsRequest != null && !awsRequest.Headers.ContainsKey(CorrelationKeys.CorrelationId))
             {
                 awsRequest.Headers[CorrelationKeys.CorrelationId] = CorrelationScope.Current.CorrelationId.ToString();

--- a/src/Albelli.Correlation.AmazonSqs/SqsCorrelationHeaderPipelineHandler.cs
+++ b/src/Albelli.Correlation.AmazonSqs/SqsCorrelationHeaderPipelineHandler.cs
@@ -23,10 +23,15 @@ namespace Albelli.Correlation.AmazonSqs
         private static void AddCorrelationAttributeIfAbsent(IRequestContext requestContext)
         {
             //that piece of code works only *after* Marshaller
-            var awsRequest = requestContext.Request;
+            var awsRequest = requestContext?.Request;
+
             if (awsRequest != null && !awsRequest.Headers.ContainsKey(CorrelationKeys.CorrelationId))
             {
-                awsRequest.Headers[CorrelationKeys.CorrelationId] = CorrelationScope.Current.CorrelationId.ToString();
+                var currentScope = CorrelationScope.Current;
+                if (currentScope != null)
+                {
+                    awsRequest.Headers[CorrelationKeys.CorrelationId] = currentScope.CorrelationId.ToString();
+                }
             }
         }
     }


### PR DESCRIPTION
The SNS Header Pipeline Handler is trying to insert a correlation id when requesting the start up parameters from the AWS Parameter store. Given the RequestContext is null the functions are unable to start properly.

![image](https://user-images.githubusercontent.com/5505626/80953309-8c65a200-8dfb-11ea-9ff4-9e50b1bd3a35.png)

![image](https://user-images.githubusercontent.com/5505626/80953464-dfd7f000-8dfb-11ea-90df-4d98149b34d3.png)
