### PR TITLE
SS-37 Don't fail if the old correlation id is all zeroes

### DIFF
--- a/src/Albelli.Correlation.Http.Server/CorrelationDiagnosticListenerSubscriber.cs
+++ b/src/Albelli.Correlation.Http.Server/CorrelationDiagnosticListenerSubscriber.cs
@@ -110,7 +110,10 @@ namespace Albelli.Correlation.Http.Server
         {
             if (context.Request.Headers.TryGetValue(CorrelationKeys.CorrelationId, out var headers)
                 && headers.Count >= 1
-                && Guid.TryParse(headers[0], out var correlationId))
+                && Guid.TryParse(headers[0], out var correlationId)
+                // all zeroes is not a valid argument to ActivityTraceId.CreateFrom where it would be fed
+                // so while in the older system it was wrong but technically valid, we have to discard it now
+                && correlationId != Guid.Empty)
             {
                 id = correlationId;
                 return true;


### PR DESCRIPTION
One of our systems had a badly configuration correlation id of all zeroes (00000000-0000-0000-0000-000000000000). This brings the API using Albelli.Correlation.Http.Server down because all zeroes is not a valid argument to [ActivityTraceId.CreateFrom](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitytraceid.createfromstring?view=netcore-3.1#System_Diagnostics_ActivityTraceId_CreateFromString_System_ReadOnlySpan_System_Char__).

While we've fixed the misconfiguration at the caller side, the issue presents a vulnerability and has to be fixed. To fix it, we don't treat all zeroes as a valid correlation id.